### PR TITLE
Constant for sequence coordinates schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1736,6 +1736,30 @@
                         </configuration>
                     </execution>
 
+                    <!-- GENERATE CORE CONSTANTS -->
+                    <execution>
+                        <id>generate-sequence-coordinate-constants</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <!-- execute Java programs in the same VM -->
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.rcsb.mojave.tools.core.GenerateSchemaConstants</mainClass>
+                            <arguments>
+                                <!-- Location of the JSON Schema file(s). -->
+                                <argument>-i</argument>
+                                <argument>${project.build.directory}/${sequence.coordinates.schema.location}</argument>
+                                <!-- Target directory for generated Java source files. -->
+                                <argument>-o</argument>
+                                <argument>${project.build.directory}/generated-sources/classes</argument>
+                                <!-- Target fully qualified class name used for generated Java class. -->
+                                <argument>-t</argument>
+                                <argument>org.rcsb.mojave.SequenceCoordinatesConstants</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+
                     <!-- GENERATE CORE ENUMS -->
                     <execution>
                         <id>generate-schema-enums</id>


### PR DESCRIPTION
Pull request to open a discussion if sequence coordinates schema should have its constants class or should be part of CoreConstant. If the second, we need to modify mojave-tools to allow schema from multiple directories, aggregation if the output class already exists, or any aggregation solution.

Ping @josemduarte 