### PR TITLE
Update PDBx/mmCIF to latest version (5.406) and address RO-4372 & RO-4392

### DIFF
--- a/schemas/exchange/min-meta/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/schemas/exchange/min-meta/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -89,6 +89,7 @@
                ],
                "description": "The full name of the component.",
                "rcsb_search_context": [
+                  "exact-match",
                   "full-text",
                   "suggest"
                ],
@@ -504,6 +505,7 @@
                   "enum": [
                      "Create component",
                      "Initial release",
+                     "Modify PCM",
                      "Modify aromatic_flag",
                      "Modify atom id",
                      "Modify backbone",
@@ -4427,7 +4429,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.3",
-   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 7.1.3"
+   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.4",
+   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 7.1.4"
 }

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -886,13 +886,23 @@
                   ],
                   "description": "Y/N if using serial crystallography experiment in which multiple crystals contribute to each diffraction frame in the experiment.",
                   "rcsb_search_context": [
-                     "full-text"
+                     "exact-match"
                   ],
-                  "rcsb_full_text_priority": 1,
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "Y/N if using serial crystallography experiment in which multiple crystals contribute to each diffraction frame in the experiment.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Diffraction Serial Crystal Experiment",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "X-ray Data Collection Details",
+                        "priority_order": 55
                      }
                   ]
                }
@@ -4408,6 +4418,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ],
                   "description": "The type of instrument used in the vitrification process.",
@@ -7023,7 +7034,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7094,7 +7105,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor"
+                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor"
                ],
                "description": "Code for status of chemical shift data file.",
                "rcsb_enum_annotated": [
@@ -7116,7 +7127,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7171,7 +7182,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of NMR constraints file.",
                "rcsb_enum_annotated": [
@@ -7193,7 +7204,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7247,7 +7258,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of structure factor file.",
                "rcsb_enum_annotated": [
@@ -7265,7 +7276,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -8856,10 +8867,14 @@
                      "AVANCE III HD",
                      "WH",
                      "WM",
+                     "AC+",
+                     "Alpha",
                      "AM",
                      "AMX",
+                     "AMX II",
                      "DMX",
                      "DRX",
+                     "DSX",
                      "MSL",
                      "OMEGA",
                      "OMEGA PSG",
@@ -8871,10 +8886,15 @@
                      "EX",
                      "LA",
                      "ECP",
-                     "VXRS",
+                     "Infinityplus",
+                     "Mercury",
+                     "VNMRS",
+                     "VXR",
                      "UNITY",
+                     "UNITY INOVA",
                      "UNITYPLUS",
-                     "INOVA"
+                     "INOVA",
+                     "home-built"
                   ],
                   "description": "The model of the NMR spectrometer.",
                   "rcsb_search_context": [
@@ -11073,7 +11093,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "X-ray Data Collection Details",
-                     "priority_order": 60
+                     "priority_order": 65
                   }
                ]
             },
@@ -11097,7 +11117,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "X-ray Data Collection Details",
-                     "priority_order": 55
+                     "priority_order": 60
                   }
                ]
             },
@@ -15728,7 +15748,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.0.3"
 }

--- a/schemas/exchange/schema_mapping/schema_def-bird_chem_comp_core-ANY.json
+++ b/schemas/exchange/schema_mapping/schema_def-bird_chem_comp_core-ANY.json
@@ -1322,6 +1322,7 @@
                "ENUMERATION": [
                   "Create component",
                   "Initial release",
+                  "Modify PCM",
                   "Modify aromatic_flag",
                   "Modify atom id",
                   "Modify backbone",
@@ -7346,7 +7347,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "bird_chem_comp_core",
-            "VERSION": "7.1.3"
+            "VERSION": "7.1.4"
          }
       ],
       "COLLECTION_DOCUMENT_ATTRIBUTE_NAMES": {

--- a/schemas/exchange/schema_mapping/schema_def-chem_comp-ANY.json
+++ b/schemas/exchange/schema_mapping/schema_def-chem_comp-ANY.json
@@ -1615,6 +1615,7 @@
                "ENUMERATION": [
                   "Create component",
                   "Initial release",
+                  "Modify PCM",
                   "Modify aromatic_flag",
                   "Modify atom id",
                   "Modify backbone",
@@ -2298,7 +2299,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "chem_comp",
-            "VERSION": "5.2.3"
+            "VERSION": "5.2.4"
          }
       ],
       "COLLECTION_DOCUMENT_ATTRIBUTE_NAMES": {

--- a/schemas/exchange/schema_mapping/schema_def-pdbx_core-ANY.json
+++ b/schemas/exchange/schema_mapping/schema_def-pdbx_core-ANY.json
@@ -12427,7 +12427,8 @@
                   "CELLULOSE ACETATE PLUS CARBON",
                   "FORMVAR PLUS CARBON",
                   "HOLEY CARBON",
-                  "PARLODION PLUS CARBON"
+                  "PARLODION PLUS CARBON",
+                  "SILICON DIOXIDE"
                ],
                "CONTENT_CLASSES": [],
                "SUB_CATEGORIES": []
@@ -14216,6 +14217,7 @@
                   "LEICA PLUNGER",
                   "REICHERT-JUNG PLUNGER",
                   "SPOTITON",
+                  "SPT LABTECH CHAMELEON",
                   "ZEISS PLUNGE FREEZER CRYOBOX"
                ],
                "CONTENT_CLASSES": [],
@@ -99944,7 +99946,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_core_entry",
-            "VERSION": "9.0.2"
+            "VERSION": "9.0.3"
          },
          {
             "NAME": "pdbx_core_assembly",

--- a/schemas/exchange/working/bson-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/schemas/exchange/working/bson-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -121,6 +121,7 @@
                   "enum": [
                      "Create component",
                      "Initial release",
+                     "Modify PCM",
                      "Modify aromatic_flag",
                      "Modify atom id",
                      "Modify backbone",

--- a/schemas/exchange/working/bson-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/working/bson-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -1394,6 +1394,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ]
                },

--- a/schemas/exchange/working/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/schemas/exchange/working/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -89,6 +89,7 @@
                ],
                "description": "The full name of the component.",
                "rcsb_search_context": [
+                  "exact-match",
                   "full-text",
                   "suggest"
                ],
@@ -504,6 +505,7 @@
                   "enum": [
                      "Create component",
                      "Initial release",
+                     "Modify PCM",
                      "Modify aromatic_flag",
                      "Modify atom id",
                      "Modify backbone",
@@ -4427,7 +4429,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.3",
-   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 7.1.3"
+   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.4",
+   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 7.1.4"
 }

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -886,13 +886,23 @@
                   ],
                   "description": "Y/N if using serial crystallography experiment in which multiple crystals contribute to each diffraction frame in the experiment.",
                   "rcsb_search_context": [
-                     "full-text"
+                     "exact-match"
                   ],
-                  "rcsb_full_text_priority": 1,
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "Y/N if using serial crystallography experiment in which multiple crystals contribute to each diffraction frame in the experiment.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Diffraction Serial Crystal Experiment",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "X-ray Data Collection Details",
+                        "priority_order": 55
                      }
                   ]
                }
@@ -4408,6 +4418,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ],
                   "description": "The type of instrument used in the vitrification process.",
@@ -7023,7 +7034,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7094,7 +7105,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor"
+                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor"
                ],
                "description": "Code for status of chemical shift data file.",
                "rcsb_enum_annotated": [
@@ -7116,7 +7127,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7171,7 +7182,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of NMR constraints file.",
                "rcsb_enum_annotated": [
@@ -7193,7 +7204,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7247,7 +7258,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of structure factor file.",
                "rcsb_enum_annotated": [
@@ -7265,7 +7276,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -8856,10 +8867,14 @@
                      "AVANCE III HD",
                      "WH",
                      "WM",
+                     "AC+",
+                     "Alpha",
                      "AM",
                      "AMX",
+                     "AMX II",
                      "DMX",
                      "DRX",
+                     "DSX",
                      "MSL",
                      "OMEGA",
                      "OMEGA PSG",
@@ -8871,10 +8886,15 @@
                      "EX",
                      "LA",
                      "ECP",
-                     "VXRS",
+                     "Infinityplus",
+                     "Mercury",
+                     "VNMRS",
+                     "VXR",
                      "UNITY",
+                     "UNITY INOVA",
                      "UNITYPLUS",
-                     "INOVA"
+                     "INOVA",
+                     "home-built"
                   ],
                   "description": "The model of the NMR spectrometer.",
                   "rcsb_search_context": [
@@ -11073,7 +11093,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "X-ray Data Collection Details",
-                     "priority_order": 60
+                     "priority_order": 65
                   }
                ]
             },
@@ -11097,7 +11117,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "X-ray Data Collection Details",
-                     "priority_order": 55
+                     "priority_order": 60
                   }
                ]
             },
@@ -15728,7 +15748,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.0.3"
 }


### PR DESCRIPTION
This PR addresses the following.

- Update PDBx/mmCIF dictionary to the latest version (5.406)
- Add `exact-match` search context for `chem_comp.name`
- Replace `full-text` with `exact-match` search context for `diffrn.pdbx_serial_crystal_experiment` 
- Add UI metadata for `diffrn.pdbx_serial_crystal_experiment` 

