### PR TITLE
Multiple updates supporting ROs 4542, 4552, 4553, & 4555

### DIFF
--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_assembly.json
@@ -582,7 +582,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "ID(s) and Keywords",
-                     "priority_order": 15
+                     "priority_order": 25
                   }
                ]
             },

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -879,6 +879,47 @@
                         "context": "dictionary"
                      }
                   ]
+               },
+               "pdbx_DOI": {
+                  "type": "string",
+                  "examples": [
+                     "10.2210/pdb6lu7/pdb"
+                  ],
+                  "description": "Document Object Identifier (DOI) for this entry registered\nwith http://crossref.org.",
+                  "rcsb_description": [
+                     {
+                        "text": "Document Object Identifier (DOI) for this entry registered\nwith http://crossref.org.",
+                        "context": "dictionary"
+                     }
+                  ]
+               },
+               "pdbx_database_accession": {
+                  "type": "string",
+                  "examples": [
+                     "pdb_00006lu7"
+                  ],
+                  "description": "Extended accession code issued for for _database_2.database_code assigned by the database identified in\n _database_2.database_id.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "suggest"
+                  ],
+                  "rcsb_full_text_priority": 20,
+                  "rcsb_description": [
+                     {
+                        "text": "Extended accession code issued for for _database_2.database_code assigned by the database identified in\n _database_2.database_id.",
+                        "context": "dictionary"
+                     },
+                     {
+                        "text": "Database Accession",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "ID(s) and Keywords",
+                        "priority_order": 10
+                     }
+                  ]
                }
             },
             "additionalProperties": false,

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -763,6 +763,133 @@
          "uniqueItems": true,
          "rcsb_nested_indexing": true
       },
+      "database_2": {
+         "type": "array",
+         "items": {
+            "type": "object",
+            "properties": {
+               "database_code": {
+                  "type": "string",
+                  "examples": [
+                     "1ABC",
+                     "ABCDEF"
+                  ],
+                  "description": "The code assigned by the database identified in\n _database_2.database_id.",
+                  "rcsb_search_context": [
+                     "exact-match"
+                  ],
+                  "rcsb_full_text_priority": 10,
+                  "rcsb_description": [
+                     {
+                        "text": "The code assigned by the database identified in\n _database_2.database_id.",
+                        "context": "dictionary"
+                     },
+                     {
+                        "text": "Database Code",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "ID(s) and Keywords",
+                        "priority_order": 15
+                     }
+                  ]
+               },
+               "database_id": {
+                  "type": "string",
+                  "enum": [
+                     "AlphaFoldDB",
+                     "BMRB",
+                     "EBI",
+                     "EMDB",
+                     "MODBASE",
+                     "ModelArchive",
+                     "NDB",
+                     "PDB",
+                     "PDB-Dev",
+                     "PDBE",
+                     "PDB_ACC",
+                     "RCSB",
+                     "SWISS-MODEL_REPOSITORY",
+                     "WWPDB"
+                  ],
+                  "description": "An abbreviation that identifies the database.",
+                  "rcsb_enum_annotated": [
+                     {
+                        "value": "AlphaFoldDB",
+                        "detail": "                                 AlphaFoldDB"
+                     },
+                     {
+                        "value": "BMRB",
+                        "detail": "                                 Biological Magnetic Reference Data Bank"
+                     },
+                     {
+                        "value": "EBI",
+                        "detail": "                                 European Bioinformatics Institute"
+                     },
+                     {
+                        "value": "EMDB",
+                        "detail": "                                 Electron Microscopy Data Bank"
+                     },
+                     {
+                        "value": "MODBASE",
+                        "detail": "                                 Database of Comparative Protein Structure Models"
+                     },
+                     {
+                        "value": "ModelArchive",
+                        "detail": "                                 ModelArchive"
+                     },
+                     {
+                        "value": "NDB",
+                        "detail": "                                 Nucleic Acid Database"
+                     },
+                     {
+                        "value": "PDB",
+                        "detail": "                                 Protein Data Bank"
+                     },
+                     {
+                        "value": "PDB-Dev",
+                        "detail": "                                 PDB-Dev integrative/hybrid methods"
+                     },
+                     {
+                        "value": "PDBE",
+                        "detail": "                                 Protein Data Bank Europe"
+                     },
+                     {
+                        "value": "PDB_ACC",
+                        "detail": "                                 Protein Data Bank Versioned Accession"
+                     },
+                     {
+                        "value": "RCSB",
+                        "detail": "                                 Research Collaboratory for Structural Bioinformatics"
+                     },
+                     {
+                        "value": "SWISS-MODEL_REPOSITORY",
+                        "detail": "                                 Swiss-Model Repository"
+                     },
+                     {
+                        "value": "WWPDB",
+                        "detail": "                                 Worldwide Protein Data Bank"
+                     }
+                  ],
+                  "rcsb_description": [
+                     {
+                        "text": "An abbreviation that identifies the database.",
+                        "context": "dictionary"
+                     }
+                  ]
+               }
+            },
+            "additionalProperties": false,
+            "required": [
+               "database_code",
+               "database_id"
+            ]
+         },
+         "minItems": 1,
+         "uniqueItems": true
+      },
       "diffrn": {
          "type": "array",
          "items": {
@@ -880,6 +1007,10 @@
                },
                "pdbx_serial_crystal_experiment": {
                   "type": "string",
+                  "enum": [
+                     "N",
+                     "Y"
+                  ],
                   "examples": [
                      "Y",
                      "N"
@@ -889,6 +1020,16 @@
                      "exact-match"
                   ],
                   "rcsb_full_text_priority": 10,
+                  "rcsb_enum_annotated": [
+                     {
+                        "value": "N",
+                        "detail": "No"
+                     },
+                     {
+                        "value": "Y",
+                        "detail": "Yes"
+                     }
+                  ],
                   "rcsb_description": [
                      {
                         "text": "Y/N if using serial crystallography experiment in which multiple crystals contribute to each diffraction frame in the experiment.",
@@ -3542,6 +3683,7 @@
                      "TFS TALOS",
                      "TFS TALOS F200C",
                      "TFS TALOS L120C",
+                     "TFS TITAN THEMIS",
                      "TFS TUNDRA",
                      "ZEISS LEO912",
                      "ZEISS LIBRA120PLUS"
@@ -5889,9 +6031,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -5901,8 +6050,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -5911,6 +6084,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -5967,9 +6144,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -5979,8 +6163,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -5989,6 +6197,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -6067,6 +6279,9 @@
                   "type": "string",
                   "enum": [
                      "Coordinate replacement",
+                     "Data added",
+                     "Data removed",
+                     "Data updated",
                      "Initial release",
                      "Obsolete",
                      "Remediation"
@@ -6101,9 +6316,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -6113,8 +6335,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -6123,6 +6369,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -6152,7 +6402,7 @@
                      "Derived calculations",
                      "Experimental data",
                      "Experimental preparation",
-                     "Initial release",
+                     "Experimental summary",
                      "Non-polymer description",
                      "Other",
                      "Polymer sequence",
@@ -6203,8 +6453,8 @@
                         "detail": "Categories describing the experimental sample preparation"
                      },
                      {
-                        "value": "Initial release",
-                        "detail": "Reports the initial release of the data contents"
+                        "value": "Experimental summary",
+                        "detail": "Categories that describe the title, authorship and molecular description"
                      },
                      {
                         "value": "Non-polymer description",
@@ -6281,9 +6531,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -6293,8 +6550,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -6303,6 +6584,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -6382,9 +6667,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -6394,8 +6686,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -6404,6 +6720,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -7361,7 +7681,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "ID(s) and Keywords",
-                        "priority_order": 10
+                        "priority_order": 20
                      }
                   ]
                },
@@ -10890,30 +11210,69 @@
                "angles_RMSZ": {
                   "type": "number",
                   "description": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Angles RMSZ",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 100
                      }
                   ]
                },
                "bonds_RMSZ": {
                   "type": "number",
                   "description": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Bonds RMSZ",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 105
                      }
                   ]
                },
                "clashscore": {
                   "type": "number",
                   "description": "This score is derived from the number of pairs of atoms in the PDB_model_num that are unusually close to each other. \nIt is calculated by the MolProbity pdbx_vrpt_software and expressed as the number or such clashes per thousand atoms.\nFor structures determined by NMR the clashscore value here will only consider label_atom_id pairs in the \nwell-defined (core) residues from ensemble analysis.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "This score is derived from the number of pairs of atoms in the PDB_model_num that are unusually close to each other. \nIt is calculated by the MolProbity pdbx_vrpt_software and expressed as the number or such clashes per thousand atoms.\nFor structures determined by NMR the clashscore value here will only consider label_atom_id pairs in the \nwell-defined (core) residues from ensemble analysis.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Clashscore",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 110
                      }
                   ]
                },
@@ -10960,10 +11319,23 @@
                "percent_ramachandran_outliers": {
                   "type": "number",
                   "description": "The percentage of residues with Ramachandran outliers.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The percentage of residues with Ramachandran outliers.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Percentage Ramachandran Outliers",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 115
                      }
                   ]
                },
@@ -10980,10 +11352,23 @@
                "percent_rotamer_outliers": {
                   "type": "number",
                   "description": "The MolProbity sidechain outlier score (a percentage).\nProtein sidechains mostly adopt certain (combinations of) preferred torsion angle values \n(called rotamers or rotameric conformers), much like their backbone torsion angles \n(as assessed in the Ramachandran analysis). MolProbity considers the sidechain conformation \nof a residue to be an outlier if its set of torsion angles is not similar to any preferred \ncombination. The sidechain outlier score is calculated as the percentage of residues \nwith an unusual sidechain conformation with respect to the total number of residues for \nwhich the assessment is available.\nExample: percent-rota-outliers=\"2.44\".\nSpecific to structure that contain protein chains and have sidechains modelled.\nFor NMR structures only the  well-defined (core) residues from ensemble analysis will be considered.\nThe percentage of residues with rotamer outliers.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The MolProbity sidechain outlier score (a percentage).\nProtein sidechains mostly adopt certain (combinations of) preferred torsion angle values \n(called rotamers or rotameric conformers), much like their backbone torsion angles \n(as assessed in the Ramachandran analysis). MolProbity considers the sidechain conformation \nof a residue to be an outlier if its set of torsion angles is not similar to any preferred \ncombination. The sidechain outlier score is calculated as the percentage of residues \nwith an unusual sidechain conformation with respect to the total number of residues for \nwhich the assessment is available.\nExample: percent-rota-outliers=\"2.44\".\nSpecific to structure that contain protein chains and have sidechains modelled.\nFor NMR structures only the  well-defined (core) residues from ensemble analysis will be considered.\nThe percentage of residues with rotamer outliers.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Percentage Rotamer Outliers",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 120
                      }
                   ]
                },
@@ -11465,7 +11850,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "ID(s) and Keywords",
-                        "priority_order": 20
+                        "priority_order": 30
                      }
                   ]
                },
@@ -11600,7 +11985,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "ID(s) and Keywords",
-                        "priority_order": 25
+                        "priority_order": 35
                      }
                   ]
                },
@@ -16326,7 +16711,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "ID(s) and Keywords",
-                     "priority_order": 35
+                     "priority_order": 45
                   }
                ]
             },
@@ -16361,7 +16746,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "ID(s) and Keywords",
-                     "priority_order": 40
+                     "priority_order": 50
                   }
                ]
             }

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -3281,7 +3281,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "ID(s) and Keywords",
-                              "priority_order": 30
+                              "priority_order": 40
                            }
                         ]
                      },

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
@@ -1687,13 +1687,13 @@
                      0.5,
                      0.95
                   ],
-                  "description": "The fractional feature coverage relative to the full entity sequence.\n For instance, the fraction of features such as CATH or SCOP domains, secondary structure elements,\n unobserved residues, or geometrical outliers relative to the length of the entity sequence.",
+                  "description": "The fractional feature coverage relative to the full entity sequence.",
                   "rcsb_search_context": [
                      "default-match"
                   ],
                   "rcsb_description": [
                      {
-                        "text": "The fractional feature coverage relative to the full entity sequence.\n For instance, the fraction of features such as CATH or SCOP domains, secondary structure elements,\n unobserved residues, or geometrical outliers relative to the length of the entity sequence.",
+                        "text": "The fractional feature coverage relative to the full entity sequence.",
                         "context": "dictionary"
                      },
                      {

--- a/schemas/exchange/schema_mapping/schema_def-pdbx_core-ANY.json
+++ b/schemas/exchange/schema_mapping/schema_def-pdbx_core-ANY.json
@@ -3466,7 +3466,9 @@
          "SCHEMA_SUB_CATEGORIES": [],
          "ATTRIBUTES": {
             "DATABASE_CODE": "database_code",
-            "DATABASE_ID": "database_id"
+            "DATABASE_ID": "database_id",
+            "PDBX_DOI": "pdbx_DOI",
+            "PDBX_DATABASE_ACCESSION": "pdbx_database_accession"
          },
          "ATTRIBUTE_MAP": {
             "DATABASE_CODE": {
@@ -3480,6 +3482,18 @@
                "ATTRIBUTE": "database_id",
                "METHOD_NAME": null,
                "ARGUMENTS": null
+            },
+            "PDBX_DOI": {
+               "CATEGORY": "database_2",
+               "ATTRIBUTE": "pdbx_DOI",
+               "METHOD_NAME": null,
+               "ARGUMENTS": null
+            },
+            "PDBX_DATABASE_ACCESSION": {
+               "CATEGORY": "database_2",
+               "ATTRIBUTE": "pdbx_database_accession",
+               "METHOD_NAME": null,
+               "ARGUMENTS": null
             }
          },
          "ATTRIBUTE_INFO": {
@@ -3489,7 +3503,7 @@
                "PRECISION": 0,
                "PRIMARY_KEY": true,
                "APP_TYPE": "char",
-               "WIDTH": 14,
+               "WIDTH": 18,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
@@ -3503,7 +3517,7 @@
                "PRECISION": 0,
                "PRIMARY_KEY": true,
                "APP_TYPE": "char",
-               "WIDTH": 10,
+               "WIDTH": 26,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
@@ -3523,6 +3537,36 @@
                   "SWISS-MODEL_REPOSITORY",
                   "WWPDB"
                ],
+               "CONTENT_CLASSES": [],
+               "SUB_CATEGORIES": []
+            },
+            "PDBX_DOI": {
+               "ORDER": 3,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "char",
+               "WIDTH": 28,
+               "ITERABLE_DELIMITER": null,
+               "EMBEDDED_ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": true,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [],
+               "SUB_CATEGORIES": []
+            },
+            "PDBX_DATABASE_ACCESSION": {
+               "ORDER": 4,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "char",
+               "WIDTH": 18,
+               "ITERABLE_DELIMITER": null,
+               "EMBEDDED_ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": true,
+               "ENUMERATION": [],
                "CONTENT_CLASSES": [],
                "SUB_CATEGORIES": []
             }

--- a/schemas/exchange/schema_mapping/schema_def-pdbx_core-ANY.json
+++ b/schemas/exchange/schema_mapping/schema_def-pdbx_core-ANY.json
@@ -3510,21 +3510,15 @@
                "ENUMERATION": [
                   "AlphaFoldDB",
                   "BMRB",
-                  "CAS",
-                  "CSD",
                   "EBI",
                   "EMDB",
-                  "ICSD",
-                  "MDF",
                   "MODBASE",
                   "ModelArchive",
-                  "NBS",
                   "NDB",
                   "PDB",
                   "PDB-Dev",
                   "PDBE",
                   "PDB_ACC",
-                  "PDF",
                   "RCSB",
                   "SWISS-MODEL_REPOSITORY",
                   "WWPDB"
@@ -4399,7 +4393,10 @@
                "EMBEDDED_ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
-               "ENUMERATION": [],
+               "ENUMERATION": [
+                  "N",
+                  "Y"
+               ],
                "CONTENT_CLASSES": [
                   "EVOLVING_CONTENT"
                ],
@@ -11608,6 +11605,7 @@
                   "TFS TALOS",
                   "TFS TALOS F200C",
                   "TFS TALOS L120C",
+                  "TFS TITAN THEMIS",
                   "TFS TUNDRA",
                   "ZEISS LEO912",
                   "ZEISS LIBRA120PLUS"
@@ -24824,9 +24822,16 @@
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
                "ENUMERATION": [
+                  "Additional map",
                   "Chemical component",
+                  "EM metadata",
+                  "FSC",
+                  "Half map",
+                  "Image",
+                  "Mask",
                   "NMR restraints",
                   "NMR shifts",
+                  "Primary map",
                   "Structure factors",
                   "Structure model"
                ],
@@ -25007,9 +25012,16 @@
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
                "ENUMERATION": [
+                  "Additional map",
                   "Chemical component",
+                  "EM metadata",
+                  "FSC",
+                  "Half map",
+                  "Image",
+                  "Mask",
                   "NMR restraints",
                   "NMR shifts",
+                  "Primary map",
                   "Structure factors",
                   "Structure model"
                ],
@@ -25117,6 +25129,9 @@
                "IS_CHAR_TYPE": true,
                "ENUMERATION": [
                   "Coordinate replacement",
+                  "Data added",
+                  "Data removed",
+                  "Data updated",
                   "Initial release",
                   "Obsolete",
                   "Remediation"
@@ -25234,9 +25249,16 @@
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
                "ENUMERATION": [
+                  "Additional map",
                   "Chemical component",
+                  "EM metadata",
+                  "FSC",
+                  "Half map",
+                  "Image",
+                  "Mask",
                   "NMR restraints",
                   "NMR shifts",
+                  "Primary map",
                   "Structure factors",
                   "Structure model"
                ],
@@ -25292,7 +25314,7 @@
                   "Derived calculations",
                   "Experimental data",
                   "Experimental preparation",
-                  "Initial release",
+                  "Experimental summary",
                   "Non-polymer description",
                   "Other",
                   "Polymer sequence",
@@ -25419,9 +25441,16 @@
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
                "ENUMERATION": [
+                  "Additional map",
                   "Chemical component",
+                  "EM metadata",
+                  "FSC",
+                  "Half map",
+                  "Image",
+                  "Mask",
                   "NMR restraints",
                   "NMR shifts",
+                  "Primary map",
                   "Structure factors",
                   "Structure model"
                ],
@@ -25593,9 +25622,16 @@
                "FILTER_TYPES": [],
                "IS_CHAR_TYPE": true,
                "ENUMERATION": [
+                  "Additional map",
                   "Chemical component",
+                  "EM metadata",
+                  "FSC",
+                  "Half map",
+                  "Image",
+                  "Mask",
                   "NMR restraints",
                   "NMR shifts",
+                  "Primary map",
                   "Structure factors",
                   "Structure model"
                ],
@@ -103930,6 +103966,7 @@
                "STRUCT",
                "STRUCT_KEYWORDS",
                "SYMMETRY",
+               "DATABASE_2",
                "MA_DATA"
             ],
             "EXCLUDE": [],

--- a/schemas/exchange/working/bson-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/working/bson-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -193,6 +193,12 @@
                      "SWISS-MODEL_REPOSITORY",
                      "WWPDB"
                   ]
+               },
+               "pdbx_DOI": {
+                  "bsonType": "string"
+               },
+               "pdbx_database_accession": {
+                  "bsonType": "string"
                }
             },
             "additionalProperties": false,

--- a/schemas/exchange/working/bson-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/working/bson-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -167,6 +167,43 @@
          "minItems": 1,
          "uniqueItems": true
       },
+      "database_2": {
+         "bsonType": "array",
+         "items": {
+            "bsonType": "object",
+            "properties": {
+               "database_code": {
+                  "bsonType": "string"
+               },
+               "database_id": {
+                  "bsonType": "string",
+                  "enum": [
+                     "AlphaFoldDB",
+                     "BMRB",
+                     "EBI",
+                     "EMDB",
+                     "MODBASE",
+                     "ModelArchive",
+                     "NDB",
+                     "PDB",
+                     "PDB-Dev",
+                     "PDBE",
+                     "PDB_ACC",
+                     "RCSB",
+                     "SWISS-MODEL_REPOSITORY",
+                     "WWPDB"
+                  ]
+               }
+            },
+            "additionalProperties": false,
+            "required": [
+               "database_code",
+               "database_id"
+            ]
+         },
+         "minItems": 1,
+         "uniqueItems": true
+      },
       "diffrn": {
          "bsonType": "array",
          "items": {
@@ -194,7 +231,11 @@
                   "bsonType": "string"
                },
                "pdbx_serial_crystal_experiment": {
-                  "bsonType": "string"
+                  "bsonType": "string",
+                  "enum": [
+                     "N",
+                     "Y"
+                  ]
                }
             },
             "additionalProperties": false,
@@ -1055,6 +1096,7 @@
                      "TFS TALOS",
                      "TFS TALOS F200C",
                      "TFS TALOS L120C",
+                     "TFS TITAN THEMIS",
                      "TFS TUNDRA",
                      "ZEISS LEO912",
                      "ZEISS LIBRA120PLUS"
@@ -1770,9 +1812,16 @@
                "data_content_type": {
                   "bsonType": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ]
@@ -1802,9 +1851,16 @@
                "data_content_type": {
                   "bsonType": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ]
@@ -1832,6 +1888,9 @@
                   "bsonType": "string",
                   "enum": [
                      "Coordinate replacement",
+                     "Data added",
+                     "Data removed",
+                     "Data updated",
                      "Initial release",
                      "Obsolete",
                      "Remediation"
@@ -1856,9 +1915,16 @@
                "data_content_type": {
                   "bsonType": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ]
@@ -1875,7 +1941,7 @@
                      "Derived calculations",
                      "Experimental data",
                      "Experimental preparation",
-                     "Initial release",
+                     "Experimental summary",
                      "Non-polymer description",
                      "Other",
                      "Polymer sequence",
@@ -1910,9 +1976,16 @@
                "data_content_type": {
                   "bsonType": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ]
@@ -1947,9 +2020,16 @@
                "data_content_type": {
                   "bsonType": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ]

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_assembly.json
@@ -582,7 +582,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "ID(s) and Keywords",
-                     "priority_order": 15
+                     "priority_order": 25
                   }
                ]
             },

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -879,6 +879,47 @@
                         "context": "dictionary"
                      }
                   ]
+               },
+               "pdbx_DOI": {
+                  "type": "string",
+                  "examples": [
+                     "10.2210/pdb6lu7/pdb"
+                  ],
+                  "description": "Document Object Identifier (DOI) for this entry registered\nwith http://crossref.org.",
+                  "rcsb_description": [
+                     {
+                        "text": "Document Object Identifier (DOI) for this entry registered\nwith http://crossref.org.",
+                        "context": "dictionary"
+                     }
+                  ]
+               },
+               "pdbx_database_accession": {
+                  "type": "string",
+                  "examples": [
+                     "pdb_00006lu7"
+                  ],
+                  "description": "Extended accession code issued for for _database_2.database_code assigned by the database identified in\n _database_2.database_id.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "suggest"
+                  ],
+                  "rcsb_full_text_priority": 20,
+                  "rcsb_description": [
+                     {
+                        "text": "Extended accession code issued for for _database_2.database_code assigned by the database identified in\n _database_2.database_id.",
+                        "context": "dictionary"
+                     },
+                     {
+                        "text": "Database Accession",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "ID(s) and Keywords",
+                        "priority_order": 10
+                     }
+                  ]
                }
             },
             "additionalProperties": false,

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -763,6 +763,133 @@
          "uniqueItems": true,
          "rcsb_nested_indexing": true
       },
+      "database_2": {
+         "type": "array",
+         "items": {
+            "type": "object",
+            "properties": {
+               "database_code": {
+                  "type": "string",
+                  "examples": [
+                     "1ABC",
+                     "ABCDEF"
+                  ],
+                  "description": "The code assigned by the database identified in\n _database_2.database_id.",
+                  "rcsb_search_context": [
+                     "exact-match"
+                  ],
+                  "rcsb_full_text_priority": 10,
+                  "rcsb_description": [
+                     {
+                        "text": "The code assigned by the database identified in\n _database_2.database_id.",
+                        "context": "dictionary"
+                     },
+                     {
+                        "text": "Database Code",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "ID(s) and Keywords",
+                        "priority_order": 15
+                     }
+                  ]
+               },
+               "database_id": {
+                  "type": "string",
+                  "enum": [
+                     "AlphaFoldDB",
+                     "BMRB",
+                     "EBI",
+                     "EMDB",
+                     "MODBASE",
+                     "ModelArchive",
+                     "NDB",
+                     "PDB",
+                     "PDB-Dev",
+                     "PDBE",
+                     "PDB_ACC",
+                     "RCSB",
+                     "SWISS-MODEL_REPOSITORY",
+                     "WWPDB"
+                  ],
+                  "description": "An abbreviation that identifies the database.",
+                  "rcsb_enum_annotated": [
+                     {
+                        "value": "AlphaFoldDB",
+                        "detail": "                                 AlphaFoldDB"
+                     },
+                     {
+                        "value": "BMRB",
+                        "detail": "                                 Biological Magnetic Reference Data Bank"
+                     },
+                     {
+                        "value": "EBI",
+                        "detail": "                                 European Bioinformatics Institute"
+                     },
+                     {
+                        "value": "EMDB",
+                        "detail": "                                 Electron Microscopy Data Bank"
+                     },
+                     {
+                        "value": "MODBASE",
+                        "detail": "                                 Database of Comparative Protein Structure Models"
+                     },
+                     {
+                        "value": "ModelArchive",
+                        "detail": "                                 ModelArchive"
+                     },
+                     {
+                        "value": "NDB",
+                        "detail": "                                 Nucleic Acid Database"
+                     },
+                     {
+                        "value": "PDB",
+                        "detail": "                                 Protein Data Bank"
+                     },
+                     {
+                        "value": "PDB-Dev",
+                        "detail": "                                 PDB-Dev integrative/hybrid methods"
+                     },
+                     {
+                        "value": "PDBE",
+                        "detail": "                                 Protein Data Bank Europe"
+                     },
+                     {
+                        "value": "PDB_ACC",
+                        "detail": "                                 Protein Data Bank Versioned Accession"
+                     },
+                     {
+                        "value": "RCSB",
+                        "detail": "                                 Research Collaboratory for Structural Bioinformatics"
+                     },
+                     {
+                        "value": "SWISS-MODEL_REPOSITORY",
+                        "detail": "                                 Swiss-Model Repository"
+                     },
+                     {
+                        "value": "WWPDB",
+                        "detail": "                                 Worldwide Protein Data Bank"
+                     }
+                  ],
+                  "rcsb_description": [
+                     {
+                        "text": "An abbreviation that identifies the database.",
+                        "context": "dictionary"
+                     }
+                  ]
+               }
+            },
+            "additionalProperties": false,
+            "required": [
+               "database_code",
+               "database_id"
+            ]
+         },
+         "minItems": 1,
+         "uniqueItems": true
+      },
       "diffrn": {
          "type": "array",
          "items": {
@@ -880,6 +1007,10 @@
                },
                "pdbx_serial_crystal_experiment": {
                   "type": "string",
+                  "enum": [
+                     "N",
+                     "Y"
+                  ],
                   "examples": [
                      "Y",
                      "N"
@@ -889,6 +1020,16 @@
                      "exact-match"
                   ],
                   "rcsb_full_text_priority": 10,
+                  "rcsb_enum_annotated": [
+                     {
+                        "value": "N",
+                        "detail": "No"
+                     },
+                     {
+                        "value": "Y",
+                        "detail": "Yes"
+                     }
+                  ],
                   "rcsb_description": [
                      {
                         "text": "Y/N if using serial crystallography experiment in which multiple crystals contribute to each diffraction frame in the experiment.",
@@ -3542,6 +3683,7 @@
                      "TFS TALOS",
                      "TFS TALOS F200C",
                      "TFS TALOS L120C",
+                     "TFS TITAN THEMIS",
                      "TFS TUNDRA",
                      "ZEISS LEO912",
                      "ZEISS LIBRA120PLUS"
@@ -5889,9 +6031,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -5901,8 +6050,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -5911,6 +6084,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -5967,9 +6144,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -5979,8 +6163,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -5989,6 +6197,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -6067,6 +6279,9 @@
                   "type": "string",
                   "enum": [
                      "Coordinate replacement",
+                     "Data added",
+                     "Data removed",
+                     "Data updated",
                      "Initial release",
                      "Obsolete",
                      "Remediation"
@@ -6101,9 +6316,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -6113,8 +6335,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -6123,6 +6369,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -6152,7 +6402,7 @@
                      "Derived calculations",
                      "Experimental data",
                      "Experimental preparation",
-                     "Initial release",
+                     "Experimental summary",
                      "Non-polymer description",
                      "Other",
                      "Polymer sequence",
@@ -6203,8 +6453,8 @@
                         "detail": "Categories describing the experimental sample preparation"
                      },
                      {
-                        "value": "Initial release",
-                        "detail": "Reports the initial release of the data contents"
+                        "value": "Experimental summary",
+                        "detail": "Categories that describe the title, authorship and molecular description"
                      },
                      {
                         "value": "Non-polymer description",
@@ -6281,9 +6531,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -6293,8 +6550,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -6303,6 +6584,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -6382,9 +6667,16 @@
                "data_content_type": {
                   "type": "string",
                   "enum": [
+                     "Additional map",
                      "Chemical component",
+                     "EM metadata",
+                     "FSC",
+                     "Half map",
+                     "Image",
+                     "Mask",
                      "NMR restraints",
                      "NMR shifts",
+                     "Primary map",
                      "Structure factors",
                      "Structure model"
                   ],
@@ -6394,8 +6686,32 @@
                   "description": "The type of file that the pdbx_audit_revision_history record refers to.",
                   "rcsb_enum_annotated": [
                      {
+                        "value": "Additional map",
+                        "detail": "EM map"
+                     },
+                     {
                         "value": "Chemical component",
                         "detail": "Chemical component definition file"
+                     },
+                     {
+                        "value": "EM metadata",
+                        "detail": "Data describing EM experimental data"
+                     },
+                     {
+                        "value": "FSC",
+                        "detail": "EM Fourier Shell Correlation data"
+                     },
+                     {
+                        "value": "Half map",
+                        "detail": "EM half map"
+                     },
+                     {
+                        "value": "Image",
+                        "detail": "Image that represents primary map"
+                     },
+                     {
+                        "value": "Mask",
+                        "detail": "EM mask map"
                      },
                      {
                         "value": "NMR restraints",
@@ -6404,6 +6720,10 @@
                      {
                         "value": "NMR shifts",
                         "detail": "NMR chemical shifts file"
+                     },
+                     {
+                        "value": "Primary map",
+                        "detail": "EM primary map"
                      },
                      {
                         "value": "Structure factors",
@@ -7361,7 +7681,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "ID(s) and Keywords",
-                        "priority_order": 10
+                        "priority_order": 20
                      }
                   ]
                },
@@ -10890,30 +11210,69 @@
                "angles_RMSZ": {
                   "type": "number",
                   "description": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Angles RMSZ",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 100
                      }
                   ]
                },
                "bonds_RMSZ": {
                   "type": "number",
                   "description": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Bonds RMSZ",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 105
                      }
                   ]
                },
                "clashscore": {
                   "type": "number",
                   "description": "This score is derived from the number of pairs of atoms in the PDB_model_num that are unusually close to each other. \nIt is calculated by the MolProbity pdbx_vrpt_software and expressed as the number or such clashes per thousand atoms.\nFor structures determined by NMR the clashscore value here will only consider label_atom_id pairs in the \nwell-defined (core) residues from ensemble analysis.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "This score is derived from the number of pairs of atoms in the PDB_model_num that are unusually close to each other. \nIt is calculated by the MolProbity pdbx_vrpt_software and expressed as the number or such clashes per thousand atoms.\nFor structures determined by NMR the clashscore value here will only consider label_atom_id pairs in the \nwell-defined (core) residues from ensemble analysis.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Clashscore",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 110
                      }
                   ]
                },
@@ -10960,10 +11319,23 @@
                "percent_ramachandran_outliers": {
                   "type": "number",
                   "description": "The percentage of residues with Ramachandran outliers.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The percentage of residues with Ramachandran outliers.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Percentage Ramachandran Outliers",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 115
                      }
                   ]
                },
@@ -10980,10 +11352,23 @@
                "percent_rotamer_outliers": {
                   "type": "number",
                   "description": "The MolProbity sidechain outlier score (a percentage).\nProtein sidechains mostly adopt certain (combinations of) preferred torsion angle values \n(called rotamers or rotameric conformers), much like their backbone torsion angles \n(as assessed in the Ramachandran analysis). MolProbity considers the sidechain conformation \nof a residue to be an outlier if its set of torsion angles is not similar to any preferred \ncombination. The sidechain outlier score is calculated as the percentage of residues \nwith an unusual sidechain conformation with respect to the total number of residues for \nwhich the assessment is available.\nExample: percent-rota-outliers=\"2.44\".\nSpecific to structure that contain protein chains and have sidechains modelled.\nFor NMR structures only the  well-defined (core) residues from ensemble analysis will be considered.\nThe percentage of residues with rotamer outliers.",
+                  "rcsb_search_context": [
+                     "default-match"
+                  ],
                   "rcsb_description": [
                      {
                         "text": "The MolProbity sidechain outlier score (a percentage).\nProtein sidechains mostly adopt certain (combinations of) preferred torsion angle values \n(called rotamers or rotameric conformers), much like their backbone torsion angles \n(as assessed in the Ramachandran analysis). MolProbity considers the sidechain conformation \nof a residue to be an outlier if its set of torsion angles is not similar to any preferred \ncombination. The sidechain outlier score is calculated as the percentage of residues \nwith an unusual sidechain conformation with respect to the total number of residues for \nwhich the assessment is available.\nExample: percent-rota-outliers=\"2.44\".\nSpecific to structure that contain protein chains and have sidechains modelled.\nFor NMR structures only the  well-defined (core) residues from ensemble analysis will be considered.\nThe percentage of residues with rotamer outliers.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Molprobity Percentage Rotamer Outliers",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Entry Features",
+                        "priority_order": 120
                      }
                   ]
                },
@@ -11465,7 +11850,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "ID(s) and Keywords",
-                        "priority_order": 20
+                        "priority_order": 30
                      }
                   ]
                },
@@ -11600,7 +11985,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "ID(s) and Keywords",
-                        "priority_order": 25
+                        "priority_order": 35
                      }
                   ]
                },
@@ -16326,7 +16711,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "ID(s) and Keywords",
-                     "priority_order": 35
+                     "priority_order": 45
                   }
                ]
             },
@@ -16361,7 +16746,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "ID(s) and Keywords",
-                     "priority_order": 40
+                     "priority_order": 50
                   }
                ]
             }

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -3281,7 +3281,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "ID(s) and Keywords",
-                              "priority_order": 30
+                              "priority_order": 40
                            }
                         ]
                      },

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
@@ -1687,13 +1687,13 @@
                      0.5,
                      0.95
                   ],
-                  "description": "The fractional feature coverage relative to the full entity sequence.\n For instance, the fraction of features such as CATH or SCOP domains, secondary structure elements,\n unobserved residues, or geometrical outliers relative to the length of the entity sequence.",
+                  "description": "The fractional feature coverage relative to the full entity sequence.",
                   "rcsb_search_context": [
                      "default-match"
                   ],
                   "rcsb_description": [
                      {
-                        "text": "The fractional feature coverage relative to the full entity sequence.\n For instance, the fraction of features such as CATH or SCOP domains, secondary structure elements,\n unobserved residues, or geometrical outliers relative to the length of the entity sequence.",
+                        "text": "The fractional feature coverage relative to the full entity sequence.",
                         "context": "dictionary"
                      },
                      {


### PR DESCRIPTION
This PR addresses the following: 
 - Load `database_2` to support extended PDB IDs
 - Update PDBx/mmCIF dictionary to the latest version `5.410`
 - Add search metadata for data items in `pdbx_vrpt_summary_geometry`
 - Update description for `rcsb_polymer_instance_feature_summary.coverage`