### PR TITLE
Remove non-ASCII delta symbol from DWH schema

### DIFF
--- a/schemas/internal/core/json-schema-core_entry.json
+++ b/schemas/internal/core/json-schema-core_entry.json
@@ -229,19 +229,19 @@
               },
               {
                 "value": "&Delta;G",
-                "name": "ΔG",
+                "name": "dG",
                 "detail": "Gibbs free energy of binding (for association reaction)",
                 "units" : "kilojoule_per_mole"
               },
               {
                 "value": "&Delta;H",
-                "name": "ΔH",
+                "name": "dH",
                 "detail": "Change in enthalpy associated with a chemical reaction",
                 "units" : "kilojoule_per_mole"
               },
               {
                 "value": "-T&Delta;S",
-                "name": "-TΔS",
+                "name": "-TdS",
                 "detail": "Change in entropy associated with a chemical reaction",
                 "units" : "kilojoule_per_mole"
               }


### PR DESCRIPTION
Harmless update that only affects display name in Advanced Search attribute menu