### PR TITLE
Use new ossrh staging server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2007,7 +2007,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
This change plus the new token I created put into the Vault maven settings.xml file, should allow maven to publish to maven central as a replacement for ossrh. At some point we'll need to migrate to the maven central plugin, but this is a stopgap measure they have provided.