### PR TITLE
Switch to maven central plugin - RO-4738

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,9 @@ jobs:
           gpg --import ~/.secrets/maven_signing_public.gpg
           passphrase=$(grep gpg.passphrase ~/.secrets/settings.xml | sed "s/.*<.*>\(.*\)<.*>/\1/")
           gpg --pinentry-mode=loopback --passphrase  "$passphrase" --import ~/.secrets/maven_signing_private.gpg
-      - name: Publish to ossrh (maven central) via maven deploy
+      - name: Publish to maven central via maven deploy
+        # Note: this will wait until the new artifact is fully validated and available publicly.
+        # The wait is essential to trigger the update-downstream job below
         run: mvn -Prelease --batch-mode --errors -U clean deploy --no-transfer-progress
       - name: Increment version for next dev cycle
         run: |
@@ -71,23 +73,9 @@ jobs:
         run: |
           git push --all
           git push --tags
-  delay-for-maven-central:
-    needs: release-mojave-model
-    runs-on:
-      - self-hosted
-      - java
-    steps:
-      # TODO This is not ideal, but needed because there are no options to wait in the maven plugin we use now (nexus-staging-maven-plugin), however
-      # TODO in the central-publishing-maven-plugin it seems to be possible for maven to hold the deploy process until maven says it's ready, see https://central.sonatype.org/publish/publish-portal-maven/
-      - name: Wait for rcsb-mojave-model artifacts to appear in maven central
-        # retry every 60 seconds x 180 times: 3 hours (after which it will fail)
-        run: |
-          MAVEN_MOJAVE_URL="https://repo1.maven.org/maven2/org/rcsb/rcsb-mojave-model/$NEW_SCHEMA_VERSION/rcsb-mojave-model-$NEW_SCHEMA_VERSION.pom"
-          echo "Will check the following URL via curl: $MAVEN_MOJAVE_URL"
-          curl --retry 180 --retry-all-errors --retry-delay 60 -f "$MAVEN_MOJAVE_URL"
   update-downstreams:
     if: inputs.skip-stack-release != true
-    needs: delay-for-maven-central
+    needs: release-mojave-model
     strategy:
       matrix:
         repos: [rcsb-redwood, rcsb-yosemite, rcsb-shape, rcsb-everglades, rcsb-sequence-coordinates]

--- a/pom.xml
+++ b/pom.xml
@@ -2007,6 +2007,11 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
+                            <!-- If this is set to false, the artifact is only staged and then needs pushing manually via the web interface at https://central.sonatype.com/publishing/deployments -->
+                            <!-- With true it publishes automatically -->
+                            <autoPublish>true</autoPublish>
+                            <!-- NOTE this is essential for the automatic github workflow to wait for the new release to be validated and publicly available -->
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1999,16 +1999,14 @@
             <id>release</id>
             <build>
                 <plugins>
-                    <!-- handles propagating the build to the staging repository -->
+                    <!-- handles uploading the build to the maven central repository -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
 


### PR DESCRIPTION
This should be enough for the release to work. This is the long-term solution that they recommend as of now.

It comes with the advantage of not needing a job to wait for the published artifact. The maven plugin does that natively.

Tested by using `mvn deploy` manually. Still not tested as an automated workflow. It still needs some changes in settings.xml secret.

