### PR TITLE
RO-4688 and RO-4904

### DIFF
--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_branched_entity.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_branched_entity.json
@@ -625,6 +625,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Branched BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Oligosaccharide/Branched Molecular Features",
+                     "priority_order": 35
                   }
                ]
             },

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
@@ -531,6 +531,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Ligand BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Nonpolymer Molecular Features",
+                     "priority_order": 30
                   }
                ]
             },

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -420,10 +420,25 @@
                      "BMH 71-18"
                   ],
                   "description": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "full-text"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },
@@ -1828,7 +1843,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 95
+                                 "priority_order": 105
                               }
                            ]
                         },
@@ -1858,7 +1873,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 90
+                                 "priority_order": 100
                               }
                            ]
                         }
@@ -2267,7 +2282,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 150
+                        "priority_order": 160
                      }
                   ]
                },
@@ -2549,7 +2564,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -2572,7 +2587,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 85
+                     "priority_order": 90
                   }
                ]
             },
@@ -2651,7 +2666,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 100
+                              "priority_order": 110
                            }
                         ]
                      },
@@ -2679,7 +2694,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 105
+                              "priority_order": 115
                            }
                         ]
                      }
@@ -3022,7 +3037,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 110
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3083,7 +3098,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 125
                      }
                   ]
                },
@@ -3233,7 +3248,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 120
+                                 "priority_order": 130
                               }
                            ]
                         },
@@ -3258,7 +3273,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 125
+                                 "priority_order": 135
                               }
                            ]
                         }
@@ -3584,6 +3599,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Polymer BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Polymer Molecular Features",
+                     "priority_order": 95
                   }
                ]
             },
@@ -3772,7 +3797,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 145
+                              "priority_order": 155
                            }
                         ]
                      },
@@ -3819,7 +3844,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 140
+                              "priority_order": 150
                            }
                         ]
                      }
@@ -4318,7 +4343,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 130
+                        "priority_order": 140
                      }
                   ]
                },
@@ -4345,7 +4370,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 135
+                        "priority_order": 145
                      }
                   ]
                },

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_branched_entity.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_branched_entity.json
@@ -625,6 +625,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Branched BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Oligosaccharide/Branched Molecular Features",
+                     "priority_order": 35
                   }
                ]
             },

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
@@ -531,6 +531,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Ligand BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Nonpolymer Molecular Features",
+                     "priority_order": 30
                   }
                ]
             },

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -420,10 +420,25 @@
                      "BMH 71-18"
                   ],
                   "description": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "full-text"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },
@@ -1828,7 +1843,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 95
+                                 "priority_order": 105
                               }
                            ]
                         },
@@ -1858,7 +1873,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 90
+                                 "priority_order": 100
                               }
                            ]
                         }
@@ -2267,7 +2282,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 150
+                        "priority_order": 160
                      }
                   ]
                },
@@ -2549,7 +2564,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -2572,7 +2587,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 85
+                     "priority_order": 90
                   }
                ]
             },
@@ -2651,7 +2666,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 100
+                              "priority_order": 110
                            }
                         ]
                      },
@@ -2679,7 +2694,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 105
+                              "priority_order": 115
                            }
                         ]
                      }
@@ -3022,7 +3037,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 110
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3083,7 +3098,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 125
                      }
                   ]
                },
@@ -3233,7 +3248,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 120
+                                 "priority_order": 130
                               }
                            ]
                         },
@@ -3258,7 +3273,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 125
+                                 "priority_order": 135
                               }
                            ]
                         }
@@ -3584,6 +3599,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Polymer BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Polymer Molecular Features",
+                     "priority_order": 95
                   }
                ]
             },
@@ -3772,7 +3797,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 145
+                              "priority_order": 155
                            }
                         ]
                      },
@@ -3819,7 +3844,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 140
+                              "priority_order": 150
                            }
                         ]
                      }
@@ -4318,7 +4343,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 130
+                        "priority_order": 140
                      }
                   ]
                },
@@ -4345,7 +4370,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 135
+                        "priority_order": 145
                      }
                   ]
                },


### PR DESCRIPTION
This PR addresses RO-4688 and RO-4904. 

 - RO-4688: Add search metadata for `entity_src_gen.gene_src_strain`
 - RO-4904: Add search UI metadata for `rcsb_polymer_entity_container_identifiers.prd_id`, `rcsb_nonpolymer_entity_container_identifiers.prd_id`, and `rcsb_branched_entity_container_identifiers.prd_id`