### PR TITLE
Remove search context for rcsb_cluster_membership.cluster_id and rcsb_cluster_membership.identity

### DIFF
--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_assembly.json
@@ -328,10 +328,10 @@
                      "MORE",
                      "SSA (A^2)"
                   ],
-                  "description": "The property type for the assembly.",
+                  "description": "The property type for the assembly.\n ABSA (A^2) is the \"Total buried surface area (A^2)\"\n SSA (A^2) is \"Surface area for the complex (A^2)\"\n MORE is \"Internal energy (kcal/mol)\"",
                   "rcsb_description": [
                      {
-                        "text": "The property type for the assembly.",
+                        "text": "The property type for the assembly.\n ABSA (A^2) is the \"Total buried surface area (A^2)\"\n SSA (A^2) is \"Surface area for the complex (A^2)\"\n MORE is \"Internal energy (kcal/mol)\"",
                         "context": "dictionary"
                      }
                   ]

--- a/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/schemas/exchange/min-meta/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -1613,34 +1613,20 @@
                "cluster_id": {
                   "type": "integer",
                   "description": "Identifier for a cluster at the specified level of sequence identity within the cluster data set.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "Identifier for a cluster at the specified level of sequence identity within the cluster data set.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Cluster Identifier",
-                        "context": "brief"
                      }
                   ]
                },
                "identity": {
                   "type": "integer",
                   "description": "Sequence identity expressed as an integer percent value.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "Sequence identity expressed as an integer percent value.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Cluster Sequence Identity",
-                        "context": "brief"
                      }
                   ]
                }

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_assembly.json
@@ -328,10 +328,10 @@
                      "MORE",
                      "SSA (A^2)"
                   ],
-                  "description": "The property type for the assembly.",
+                  "description": "The property type for the assembly.\n ABSA (A^2) is the \"Total buried surface area (A^2)\"\n SSA (A^2) is \"Surface area for the complex (A^2)\"\n MORE is \"Internal energy (kcal/mol)\"",
                   "rcsb_description": [
                      {
-                        "text": "The property type for the assembly.",
+                        "text": "The property type for the assembly.\n ABSA (A^2) is the \"Total buried surface area (A^2)\"\n SSA (A^2) is \"Surface area for the complex (A^2)\"\n MORE is \"Internal energy (kcal/mol)\"",
                         "context": "dictionary"
                      }
                   ]

--- a/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/schemas/exchange/working/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -1613,34 +1613,20 @@
                "cluster_id": {
                   "type": "integer",
                   "description": "Identifier for a cluster at the specified level of sequence identity within the cluster data set.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "Identifier for a cluster at the specified level of sequence identity within the cluster data set.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Cluster Identifier",
-                        "context": "brief"
                      }
                   ]
                },
                "identity": {
                   "type": "integer",
                   "description": "Sequence identity expressed as an integer percent value.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "Sequence identity expressed as an integer percent value.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Cluster Sequence Identity",
-                        "context": "brief"
                      }
                   ]
                }


### PR DESCRIPTION
This PR 
 - Removes search context for `rcsb_cluster_membership.cluster_id` and `rcsb_cluster_membership.identity`
 - Updates PDBx/mmCIF dictionary to `v5.423`