### PR TITLE
No search context anywhere in groups

### DIFF
--- a/schemas/internal/groups/json-schema-group_core.json
+++ b/schemas/internal/groups/json-schema-group_core.json
@@ -11,9 +11,6 @@
   "properties": {
     "rcsb_id": {
       "type": "string",
-      "rcsb_search_context": [
-        "exact-match"
-      ],
       "description": "A unique textual identifier for a group"
     },
     "rcsb_group_container_identifiers": {
@@ -26,10 +23,7 @@
       "properties": {
         "group_id": {
           "type": "string",
-          "description": "A unique textual identifier for a group",
-          "rcsb_search_context": [
-            "exact-match"
-          ]
+          "description": "A unique textual identifier for a group"
         },
         "group_provenance_id": {
           "$ref": "json-schema-group_provenance.json#/properties/rcsb_group_provenance_container_identifiers/properties/group_provenance_id"
@@ -46,10 +40,7 @@
         "group_member_ids": {
           "type": "array",
           "items": {
-            "type": "string",
-            "rcsb_search_context": [
-              "exact-match"
-            ]
+            "type": "string"
           },
           "minItems": 1,
           "uniqueItems": true,
@@ -66,10 +57,7 @@
       ],
       "properties": {
         "group_name": {
-          "type": "string",
-          "rcsb_search_context": [
-            "exact-match"
-          ]
+          "type": "string"
         },
         "group_description": {
           "type": "string"
@@ -86,10 +74,7 @@
           "description": "Granularity of group members identifiers"
         },
         "group_members_count": {
-          "type": "integer",
-          "rcsb_search_context": [
-            "default-match"
-          ]
+          "type": "integer"
         }
       }
     },
@@ -99,9 +84,6 @@
         "similarity_cutoff": {
           "type": "number",
           "description": "Degree of similarity expressed as a floating-point number",
-          "rcsb_search_context": [
-            "default-match"
-          ],
           "rcsb_description": [
             {
               "text": "Degree of similarity expressed as a floating-point number",

--- a/schemas/internal/groups/json-schema-group_polymer_entity.json
+++ b/schemas/internal/groups/json-schema-group_polymer_entity.json
@@ -24,10 +24,7 @@
                 "detail": "The higher the coverage, the better"
               }
             ],
-            "description": "Defines ranking option applicable to group members",
-            "rcsb_search_context": [
-              "exact-match"
-            ]
+            "description": "Defines ranking option applicable to group members"
           },
           "group_members": {
             "type": "array",
@@ -39,24 +36,15 @@
               ],
               "properties": {
                 "member_id": {
-                  "type": "string",
-                  "rcsb_search_context": [
-                    "exact-match"
-                  ]
+                  "type": "string"
                 },
                 "rank": {
                   "type": "integer",
-                  "description": "Reflects a relationship between group members such that, for any two members the first is ranked higher (smaller rank value) than the second",
-                  "rcsb_search_context": [
-                    "default-match"
-                  ]
+                  "description": "Reflects a relationship between group members such that, for any two members the first is ranked higher (smaller rank value) than the second"
                 },
                 "original_score": {
                   "type": "number",
-                  "description": "Quantifies the criteria used for ranking",
-                  "rcsb_search_context": [
-                    "default-match"
-                  ]
+                  "description": "Quantifies the criteria used for ranking"
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
Previously (in current prod) the group collections were not wired in at indexing time, so all these search_context metadata was present but actually had no effect. 

With the new implementation in indexing where the group collections are wired in, we need to remove the search context explicitly or otherwise all these fields go into ES mappings.

Note this is to merge into the existing branch ro5005